### PR TITLE
Add Enemy Healthbar && Fix player shooting logic

### DIFF
--- a/Assets/Resources/Bullet.prefab
+++ b/Assets/Resources/Bullet.prefab
@@ -95,7 +95,7 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3122080028253504167}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 0.5
@@ -151,5 +151,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d213563ff72fb2429f19620dd07ceb8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 0
-  speed: 0
+  damage: 10
+  speed: 15

--- a/Assets/Resources/Enemy.prefab
+++ b/Assets/Resources/Enemy.prefab
@@ -1,5 +1,182 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1514120600145409954
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4539827647728419274}
+  - component: {fileID: 4662099298774273167}
+  - component: {fileID: 4114681348173449690}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4539827647728419274
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1514120600145409954}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8972655730752228630}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4662099298774273167
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1514120600145409954}
+  m_CullTransparentMesh: 1
+--- !u!114 &4114681348173449690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1514120600145409954}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 2
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5067524705538406036
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8466651007549601739}
+  - component: {fileID: 8289439531136765174}
+  - component: {fileID: 1854179629733703263}
+  - component: {fileID: 516035041852400717}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8466651007549601739
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067524705538406036}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8972655730752228630}
+  m_Father: {fileID: 5108304410460496532}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1.3}
+  m_SizeDelta: {x: 2, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &8289439531136765174
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067524705538406036}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &1854179629733703263
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067524705538406036}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &516035041852400717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5067524705538406036}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
 --- !u!1 &5108304409745194433
 GameObject:
   m_ObjectHideFlags: 0
@@ -118,7 +295,7 @@ GameObject:
   - component: {fileID: 3646250638607942395}
   m_Layer: 7
   m_Name: Enemy
-  m_TagString: Untagged
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -136,6 +313,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5108304409745194434}
+  - {fileID: 8466651007549601739}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -336,3 +514,208 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 100
+  healthSlider: {fileID: 5153177665681103250}
+  virtual_cam: {fileID: 0}
+--- !u!1 &7021749010433218192
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5144384767255385247}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5144384767255385247
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7021749010433218192}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4089588746629241895}
+  m_Father: {fileID: 8972655730752228630}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7182400791904485252
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4089588746629241895}
+  - component: {fileID: 2591914923298062407}
+  - component: {fileID: 5971074017564253750}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4089588746629241895
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7182400791904485252}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5144384767255385247}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2591914923298062407
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7182400791904485252}
+  m_CullTransparentMesh: 1
+--- !u!114 &5971074017564253750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7182400791904485252}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8229439854832352025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8972655730752228630}
+  - component: {fileID: 5153177665681103250}
+  m_Layer: 5
+  m_Name: HealthSlider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8972655730752228630
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8229439854832352025}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 0.2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4539827647728419274}
+  - {fileID: 5144384767255385247}
+  m_Father: {fileID: 8466651007549601739}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5153177665681103250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8229439854832352025}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 5144384767255385247}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 1
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/Resources/Player.prefab
+++ b/Assets/Resources/Player.prefab
@@ -206,6 +206,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2129553893955934209}
+  - component: {fileID: 2059696932650946525}
   m_Layer: 0
   m_Name: Gun
   m_TagString: Weapon
@@ -230,6 +231,25 @@ Transform:
   m_Father: {fileID: 5352331137499062312}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2059696932650946525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002404234181138689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b558c32b265b0534288c78c0ab68c645, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  muzzle: {fileID: 0}
+  bulletPrefab: {fileID: 3122080028253504167, guid: b41ce09d0caa4eb4ab17defa5ca7d323, type: 3}
+  layerMask:
+    serializedVersion: 2
+    m_Bits: 384
+  attackRange: 30
+  fireTimeInterval: 1
 --- !u!1 &1831215300425842322
 GameObject:
   m_ObjectHideFlags: 0
@@ -507,6 +527,7 @@ GameObject:
   - component: {fileID: 6955203693822827252}
   - component: {fileID: 2721983955573791418}
   - component: {fileID: 4132571221110126371}
+  - component: {fileID: 7819450821971473574}
   m_Layer: 6
   m_Name: Player
   m_TagString: Player
@@ -694,12 +715,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b558c32b265b0534288c78c0ab68c645, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerGun: {fileID: 1002404234181138689}
+  muzzle: {fileID: 0}
   bulletPrefab: {fileID: 3122080028253504167, guid: b41ce09d0caa4eb4ab17defa5ca7d323, type: 3}
   layerMask:
     serializedVersion: 2
     m_Bits: 384
-  attackRange: 0
+  attackRange: 30
+  fireTimeInterval: 1
 --- !u!114 &926294368036530175
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -766,6 +788,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   interactText: {fileID: 1509340231984311118}
+--- !u!114 &7819450821971473574
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5352331137499062327}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60cf850b5dc71f3459397c397c77c606, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gunController: {fileID: 0}
 --- !u!1 &5674600873166414637
 GameObject:
   m_ObjectHideFlags: 0
@@ -779,7 +814,7 @@ GameObject:
   - component: {fileID: 6249076894392087006}
   m_Layer: 0
   m_Name: InteractArea
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1000,7 +1035,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 0}
   m_FillRect: {fileID: 8451916282793670694}
   m_HandleRect: {fileID: 0}

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -1421,7 +1421,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4044717213e31446939f7bd49c896ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_TrackedObjectOffset: {x: 0, y: 1, z: 0}
   m_LookaheadTime: 0
   m_LookaheadSmoothing: 0
   m_LookaheadIgnoreY: 0

--- a/Assets/Scripts/InGame/Bullet.cs
+++ b/Assets/Scripts/InGame/Bullet.cs
@@ -5,33 +5,30 @@ using Photon.Pun;
 
 public class Bullet : MonoBehaviourPunCallbacks
 {
-    public float damage;
-    public float speed;
-    private Vector3 aimPoint;
-    private Vector3 expiringPoint;
-    // Start is called before the first frame update
-    void Start()
-    {
-        damage = 10f;
-        speed = 0.05f;
-    }
+    public float damage = 10f;
+    public float speed = 2f;
+
+    private Vector3 startPosition;
+    private float attackRange = 100f;
+
     private void Update() {
-        transform.position = Vector3.MoveTowards(transform.position, expiringPoint, speed);
-        if(transform.position == expiringPoint) {
-            Debug.Log("Bullet is expired: ");
+        transform.position += transform.forward * Time.deltaTime * speed;
+
+        if(Vector3.Distance(startPosition, transform.position) >= attackRange) {
             PhotonNetwork.Destroy(this.gameObject);
         }
     }
 
     [PunRPC]
-    public void Setup(Vector3 aimPoint, float attackRange) {
-        this.aimPoint = aimPoint;
-        this.expiringPoint = transform.position + (aimPoint - transform.position).normalized * attackRange;
+    public void Setup(float attackRange) {
+        this.attackRange = attackRange;
+        startPosition = transform.position;
     }
 
-    private void OnCollisionEnter(Collision other) {
-        if(other.gameObject.tag == "Weapon" || other.gameObject.tag == "Player") return;
-        Debug.Log("Bullet hit: "+other.gameObject.name);
-        PhotonNetwork.Destroy(this.gameObject);
+    private void OnTriggerEnter(Collider other) {
+        if(other.gameObject.tag == "Enemy" || other.gameObject.tag == "Ground") {
+            Debug.Log("Bullet hit: "+other.gameObject.name);
+            PhotonNetwork.Destroy(this.gameObject);
+        }
     }
 }

--- a/Assets/Scripts/InGame/CameraSetup.cs
+++ b/Assets/Scripts/InGame/CameraSetup.cs
@@ -7,16 +7,13 @@ using Photon.Pun;
 public class CameraSetup : MonoBehaviourPun
 {
     public CinemachineVirtualCamera followCam;
+
     private void Awake() {
         if(photonView.IsMine) {
-            followCam = FindObjectOfType<CinemachineVirtualCamera>();
+            followCam = GameObject.FindWithTag("MainCamera").GetComponent<CinemachineVirtualCamera>();
             Transform target = transform.GetComponent<PlayerMovement>().targetOfCam;
             followCam.Follow = target;
             followCam.LookAt = target;
         }
-    }
-    void Start()
-    {
-        
     }
 }

--- a/Assets/Scripts/InGame/EnemyHealth.cs
+++ b/Assets/Scripts/InGame/EnemyHealth.cs
@@ -1,8 +1,51 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
+using Photon.Pun;
+using Cinemachine;
 
 public class EnemyHealth : LivingEntity
 {
-    
+    public Slider healthSlider;
+
+    [SerializeField]
+    private CinemachineVirtualCamera virtual_cam;
+    private EnemyMovement enemyMovement;
+
+    private void Awake() {
+        enemyMovement = GetComponent<EnemyMovement>();
+        virtual_cam = GameObject.FindWithTag("MainCamera").GetComponent<CinemachineVirtualCamera>();
+    }
+
+    private void Update() {
+        healthSlider.transform.LookAt(healthSlider.transform.position + virtual_cam.transform.rotation * Vector3.back, virtual_cam.transform.rotation * Vector3.up);
+    }
+
+    protected override void OnEnable() {
+        base.OnEnable();
+
+        healthSlider.gameObject.SetActive(true);
+        healthSlider.maxValue = maxHealth;
+        healthSlider.value = health;
+    }
+
+    [PunRPC]
+    public override void RestoreHealth(float newHealth) {
+        base.RestoreHealth(newHealth);
+        healthSlider.value = health;
+    }
+
+    [PunRPC]
+    public override void OnDamage(float damage, Vector3 hitPoint, Vector3 hitDirection) {
+        base.OnDamage(damage, hitPoint, hitDirection);
+        healthSlider.value = health;
+    }
+
+    public override void Die() {
+        base.Die();
+
+        healthSlider.gameObject.SetActive(false);
+        enemyMovement.enabled = false;
+    }
 }

--- a/Assets/Scripts/InGame/Player/PlayerMovement.cs
+++ b/Assets/Scripts/InGame/Player/PlayerMovement.cs
@@ -30,7 +30,6 @@ public class PlayerMovement : MonoBehaviourPun
         playerInput = GetComponent<PlayerInput>();
         playerRigidbody = GetComponent<Rigidbody>();
         gunController = GetComponent<GunController>();
-        //targetOfCam = transform.GetChild(3);
         num_remain_jump = num_max_jump;
     }
 
@@ -43,7 +42,6 @@ public class PlayerMovement : MonoBehaviourPun
 
         Rotate();
         Jump();
-        Fire();
     }
 
     private void FixedUpdate() {
@@ -78,16 +76,6 @@ public class PlayerMovement : MonoBehaviourPun
             playerRigidbody.AddForce(jumpForce * transform.up, ForceMode.Impulse);
             num_remain_jump--;
             on_ground = false;
-        }
-    }
-
-    private void Fire() {
-        gunController.GunFireRateCalc();
-        Vector3 aimPoint = gunController.GetAimPoint();
-        gunController.TraceAim(aimPoint);
-        if(playerInput.fire)
-        {
-            gunController.Fire(aimPoint);
         }
     }
 

--- a/Assets/Scripts/InGame/Player/PlayerShooter.cs
+++ b/Assets/Scripts/InGame/Player/PlayerShooter.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+
+public class PlayerShooter : MonoBehaviourPun
+{
+    private PlayerInput playerInput;
+    [SerializeField]
+    private GunController gunController;
+
+    void Awake()
+    {
+        playerInput = GetComponent<PlayerInput>();
+        gunController = transform.Find("Gun").gameObject.GetComponent<GunController>();
+    }
+
+    void Update()
+    {
+        if(!photonView.IsMine)
+        {
+            return;
+        }
+
+        if(playerInput.fire) {
+            gunController.Fire();
+        }
+    }
+
+    private void OnEnable() {
+        gunController.gameObject.SetActive(true);
+    }
+
+    private void OnDisable() {
+        gunController.gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/InGame/Player/PlayerShooter.cs.meta
+++ b/Assets/Scripts/InGame/Player/PlayerShooter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60cf850b5dc71f3459397c397c77c606
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SimpleNaturePack/SimpleNaturePack_HDRP_2018.4_v1.22.unitypackage.meta
+++ b/Assets/SimpleNaturePack/SimpleNaturePack_HDRP_2018.4_v1.22.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3b4dc5f685f8edc4bbba6fb0c8ea39ba
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SimpleNaturePack/SimpleNaturePack_LWRP_2018.4_v1.22.unitypackage.meta
+++ b/Assets/SimpleNaturePack/SimpleNaturePack_LWRP_2018.4_v1.22.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8851c5995be5f704babebf752d60b4e2
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SimpleNaturePack/SimpleNaturePack_URP_2019.3_v1.22.unitypackage.meta
+++ b/Assets/SimpleNaturePack/SimpleNaturePack_URP_2019.3_v1.22.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 88c6da05db186cb44a4453fd624b31b2
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites.meta
+++ b/Assets/Sprites.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8aadf0be7d700214186749fe2226f131
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
적의 체력바 추가
 - 플레이어 위치에 따라 체력바가 회전하여 적의 회전과 관계없이 항상 정면 상태의 체력바를 확인할 수 있다.

PlayerShooter 코드를 추가하여 플레이어의 입력에 따른 총의 발사를 처리
총알을 생성할 때 회전을 총의 회전과 같게 하여 총알의 방향 결정
총알이 사정거리에 도달함을 확인하는 부분 수정