### PR TITLE
Gun Rotation

### DIFF
--- a/Assets/ImportedAssets/SimpleNaturePack/SimpleNaturePack_HDRP_2018.4_v1.22.unitypackage.meta
+++ b/Assets/ImportedAssets/SimpleNaturePack/SimpleNaturePack_HDRP_2018.4_v1.22.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3b4dc5f685f8edc4bbba6fb0c8ea39ba
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ImportedAssets/SimpleNaturePack/SimpleNaturePack_LWRP_2018.4_v1.22.unitypackage.meta
+++ b/Assets/ImportedAssets/SimpleNaturePack/SimpleNaturePack_LWRP_2018.4_v1.22.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8851c5995be5f704babebf752d60b4e2
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ImportedAssets/SimpleNaturePack/SimpleNaturePack_URP_2019.3_v1.22.unitypackage.meta
+++ b/Assets/ImportedAssets/SimpleNaturePack/SimpleNaturePack_URP_2019.3_v1.22.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 88c6da05db186cb44a4453fd624b31b2
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/RobotPlayer.prefab
+++ b/Assets/Resources/RobotPlayer.prefab
@@ -2320,6 +2320,9 @@ MonoBehaviour:
   fireTimeInterval: 0.15
   damagePopupXPositionNoise: 0.5
   bulletLineLifeTime: 0.03
+  spine: {fileID: 8416483574672996526}
+  arm_position_left: {fileID: 8416483574672996550}
+  arm_position_right: {fileID: 8416483574672996548}
   animController: {fileID: 2195111620641564800}
 --- !u!120 &6967598129991055666
 LineRenderer:

--- a/Assets/Scripts/InGame/Player/RobotPlayer/RobotGunController.cs
+++ b/Assets/Scripts/InGame/Player/RobotPlayer/RobotGunController.cs
@@ -6,12 +6,18 @@ public class RobotGunController : GunController
 {
     public float bulletLineLifeTime = 0.03f;
 
+    public Transform spine;
+    public Transform arm_position_left;
+    public Transform arm_position_right;
+
     private LineRenderer bulletLineRenderer;
     [SerializeField]
     private PlayerAnimationController animController;
-    private Transform spine;
-    private Animator a;
-    Vector3 aimPoint;
+    
+    private Vector3 aimPoint;
+    private Vector3 spine_rotation_offset = new Vector3(0, -40, -100);
+    private Vector3 arm_position_left_rotation_offset = new Vector3(0, 90, -45);
+    private Vector3 arm_position_right_rotation_offset = new Vector3(0, 90, -45);
 
     private void Awake() {
         bulletLineRenderer = GetComponent<LineRenderer>();
@@ -22,19 +28,23 @@ public class RobotGunController : GunController
         //animController = gameObject.transform.parent.GetComponent<PlayerAnimationController>();
     }
     private void Start() {
-        a = animController.animator;
-        spine = animController.animator.GetBoneTransform(HumanBodyBones.Spine); // upper body
+
     }
 
     protected override void Update() {
         base.Update();
     }
     
-    Vector3 offset = new Vector3(0, -40, -100);
+    
     private void LateUpdate() {
         spine.LookAt(aimPoint);
-        spine.rotation = spine.rotation * Quaternion.Euler(offset);
-        
+        spine.rotation = spine.rotation * Quaternion.Euler(spine_rotation_offset);
+        arm_position_left.LookAt(aimPoint);
+        arm_position_right.LookAt(aimPoint);
+        arm_position_left.rotation = arm_position_left.rotation * Quaternion.Euler(arm_position_left_rotation_offset);
+        arm_position_right.rotation = arm_position_right.rotation * Quaternion.Euler(arm_position_right_rotation_offset);
+
+
         //this.transform.LookAt(aimPoint);
         //transform.rotation = transform.rotation * Quaternion.Euler(offset);
     }


### PR DESCRIPTION
총의 회전을 임시로 해결

수정해야 할 내용
 - 위를 바라보거나 아래를 바라볼 때 총과 손의 위치가 일치하지 않음
 - 총구의 위치가 총과 같이 변하도록 해야 함