### PR TITLE
점프, 애니메이션컨트롤러 수정

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -51,6 +51,8 @@ MonoBehaviour:
   - ShootEffectProcessOnClients
   - ShootProcessOnServer
   - CreateDamagePopup
+  - RpcJump
+  - RpcChangeAnimationState
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/Assets/Scripts/InGame/AnimationController.cs
+++ b/Assets/Scripts/InGame/AnimationController.cs
@@ -13,11 +13,16 @@ public class AnimationController : MonoBehaviourPun
     }
 
     [PunRPC]
-    public void ChangeAnimationState(string newState) {
-        if(currentState == newState) return;
+    public void RpcChangeAnimationState(string newState) {
+        //if(currentState == newState) return;
 
         animator.Play(newState);
 
         currentState = newState;
+    }
+
+    public void ChangeAnimationState(string newState) {
+        if(currentState == newState) return;
+        photonView.RPC("RpcChangeAnimationState", RpcTarget.All, newState);
     }
 }

--- a/Assets/Scripts/InGame/Enemy/SlimeMovement.cs
+++ b/Assets/Scripts/InGame/Enemy/SlimeMovement.cs
@@ -20,8 +20,8 @@ public class SlimeMovement : EnemyMovement
 
         if(isTargetInAttackRange) {
             if(!enemyHealth.dead && Time.time >= lastAttackTime + attackForeDelay) {
-                //animController.ChangeAnimationState(SlimeAnimationController.AnimState.Attack01.ToString());    //anim
-                animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, SlimeAnimationController.AnimState.Attack01.ToString());
+                animController.ChangeAnimationState(SlimeAnimationController.AnimState.Attack01.ToString());    //anim
+                //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, SlimeAnimationController.AnimState.Attack01.ToString());
                 lastAttackTime = Time.time;
                 Attack(targetEntity);
             }
@@ -34,8 +34,8 @@ public class SlimeMovement : EnemyMovement
             if(hasTarget && !isTargetInAttackRange) {
                 navMeshAgent.isStopped = false;
                 Vector3 distance = targetEntity.transform.position - transform.position;
-                //animController.ChangeAnimationState(SlimeAnimationController.AnimState.WalkFWD.ToString());     //anim
-                animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, SlimeAnimationController.AnimState.WalkFWD.ToString());
+                animController.ChangeAnimationState(SlimeAnimationController.AnimState.WalkFWD.ToString());     //anim
+                //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, SlimeAnimationController.AnimState.WalkFWD.ToString());
                 navMeshAgent.SetDestination(targetEntity.transform.position - (distance.normalized * attackRange * 0.8f));
             } else {
                 navMeshAgent.isStopped = true;

--- a/Assets/Scripts/InGame/Enemy/TurtleMovement.cs
+++ b/Assets/Scripts/InGame/Enemy/TurtleMovement.cs
@@ -20,8 +20,8 @@ public class TurtleMovement : EnemyMovement
 
         if(isTargetInAttackRange) {
             if(!enemyHealth.dead && Time.time >= lastAttackTime + attackForeDelay) {
-                //animController.ChangeAnimationState(TurtleAnimationController.AnimState.Attack01.ToString());   //anim
-                animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, TurtleAnimationController.AnimState.Attack01.ToString());
+                animController.ChangeAnimationState(TurtleAnimationController.AnimState.Attack01.ToString());   //anim
+                //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, TurtleAnimationController.AnimState.Attack01.ToString());
                 lastAttackTime = Time.time;
                 Attack(targetEntity);
             }
@@ -34,8 +34,8 @@ public class TurtleMovement : EnemyMovement
             if(hasTarget && !isTargetInAttackRange) {
                 navMeshAgent.isStopped = false;
                 Vector3 distance = targetEntity.transform.position - transform.position;
-                //animController.ChangeAnimationState(TurtleAnimationController.AnimState.WalkFWD.ToString());    //anim
-                animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, TurtleAnimationController.AnimState.WalkFWD.ToString());
+                animController.ChangeAnimationState(TurtleAnimationController.AnimState.WalkFWD.ToString());    //anim
+                //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, TurtleAnimationController.AnimState.WalkFWD.ToString());
                 navMeshAgent.SetDestination(targetEntity.transform.position - (distance.normalized * attackRange * 0.8f));
             } else {
                 navMeshAgent.isStopped = true;

--- a/Assets/Scripts/InGame/Player/PlayerAnimationController.cs
+++ b/Assets/Scripts/InGame/Player/PlayerAnimationController.cs
@@ -22,7 +22,7 @@ public class PlayerAnimationController : AnimationController
     }
 
     private string currentState_second;
-
+/*
     [PunRPC]
     public void ChangeAnimationState(string newState, int layer, float normalizedTime) { // layer = -1: base layer, layer = 1: upper layer
         if(layer == -1) {
@@ -34,6 +34,26 @@ public class PlayerAnimationController : AnimationController
         }
 
         animator.Play(newState, layer, normalizedTime);
+    }
+*/
+    [PunRPC]
+    public void RpcChangeAnimationState(string newState, int layer, float normalizedTime) { // layer = -1: base layer, layer = 1: upper layer
+        if(layer == -1) {
+            currentState = newState;
+        } else { // layer == 1
+            currentState_second = newState;
+        }
+
+        animator.Play(newState, layer, normalizedTime);
+    }
+    public void ChangeAnimationState(string newState, int layer, float normalizedTime) {
+        if(layer == -1) {
+            if(currentState == newState) return;
+        } else { // layer == 1
+            if(currentState_second == newState) return;
+        }
+        photonView.RPC("RpcChangeAnimationState", RpcTarget.All, newState, layer, normalizedTime);
+        
     }
 
     [PunRPC]

--- a/Assets/Scripts/InGame/Player/PlayerMovement.cs
+++ b/Assets/Scripts/InGame/Player/PlayerMovement.cs
@@ -45,7 +45,6 @@ public class PlayerMovement : MonoBehaviourPun
         }
 
         Rotate();
-        Jump();
     }
 
     private void FixedUpdate() {
@@ -55,6 +54,10 @@ public class PlayerMovement : MonoBehaviourPun
         }
 
         Move();
+        //Jump();
+        if(playerInput.jump && numRemainJump > 0) {
+            photonView.RPC("RpcJump", RpcTarget.All);
+        }
     }
 
     protected virtual void Move() {
@@ -79,6 +82,12 @@ public class PlayerMovement : MonoBehaviourPun
             isGrounded = false;
             numRemainJump--;
         }
+    }
+    [PunRPC]
+    protected void RpcJump() {
+        playerRigidbody.AddForce(jumpForce * transform.up, ForceMode.Impulse);
+        isGrounded = false;
+        numRemainJump--;
     }
 
     protected virtual void OnCollisionEnter(Collision other) {

--- a/Assets/Scripts/InGame/Player/RobotPlayer/RobotGunController.cs
+++ b/Assets/Scripts/InGame/Player/RobotPlayer/RobotGunController.cs
@@ -73,7 +73,7 @@ public class RobotGunController : GunController
             hitPosition = muzzle.position + muzzle.forward * attackRange;
         }
         photonView.RPC("ShootEffectProcessOnClients", RpcTarget.All, hitPosition);
-        photonView.RPC("ShootProcessOnServer", RpcTarget.MasterClient, aimVector);
+        photonView.RPC("ShootProcessOnServer", RpcTarget.MasterClient);
     }
 
     [PunRPC]

--- a/Assets/Scripts/InGame/Player/RobotPlayer/RobotPlayerMovement.cs
+++ b/Assets/Scripts/InGame/Player/RobotPlayer/RobotPlayerMovement.cs
@@ -18,23 +18,28 @@ public class RobotPlayerMovement : PlayerMovement
 
         if(isGrounded) {
             if(playerInput.horizontalMove == 0 && playerInput.verticalMove == 0) {
-                animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.Idle_gunMiddle_AR.ToString(), -1, 0f);
+                //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.Idle_gunMiddle_AR.ToString(), -1, 0f);
+                animController.ChangeAnimationState(PlayerAnimationController.AnimState.Idle_gunMiddle_AR.ToString(), -1, 0f);
             }
             if(playerInput.horizontalMove != 0) {
                 if(playerInput.horizontalMove < 0) {
-                    animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.WalkLeft_Shoot_AR.ToString(), -1, 0f);
+                    //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.WalkLeft_Shoot_AR.ToString(), -1, 0f);
+                    animController.ChangeAnimationState(PlayerAnimationController.AnimState.WalkLeft_Shoot_AR.ToString(), -1, 0f);
                     Debug.Log("Left");
                 } else {
-                    animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.WalkRight_Shoot_AR.ToString(), -1, 0f);
+                    //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.WalkRight_Shoot_AR.ToString(), -1, 0f);
+                    animController.ChangeAnimationState(PlayerAnimationController.AnimState.WalkRight_Shoot_AR.ToString(), -1, 0f);
                     Debug.Log("Right");
                 }
             }
             else {
                 if(playerInput.verticalMove < 0) {
-                    animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.WalkBack_Shoot_AR.ToString(), -1, 0f);
+                    //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.WalkBack_Shoot_AR.ToString(), -1, 0f);
+                    animController.ChangeAnimationState(PlayerAnimationController.AnimState.WalkBack_Shoot_AR.ToString(), -1, 0f);
                     Debug.Log("Back");
                 } else if(playerInput.verticalMove > 0) {
-                    animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.WalkFront_Shoot_AR.ToString(), -1, 0f);
+                    //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.WalkFront_Shoot_AR.ToString(), -1, 0f);
+                    animController.ChangeAnimationState(PlayerAnimationController.AnimState.WalkFront_Shoot_AR.ToString(), -1, 0f);
                     Debug.Log("Front");
                 }
             }

--- a/Assets/Scripts/InGame/Player/RobotPlayer/RobotPlayerShooter.cs
+++ b/Assets/Scripts/InGame/Player/RobotPlayer/RobotPlayerShooter.cs
@@ -21,7 +21,8 @@ public class RobotPlayerShooter : PlayerShooter
         }
 
         if(playerInput.fire) {
-            animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.Shoot_Autoshot_AR.ToString(), 1, 0f);
+            //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.Shoot_Autoshot_AR.ToString(), 1, 0f);
+            animController.ChangeAnimationState(PlayerAnimationController.AnimState.Shoot_Autoshot_AR.ToString(), 1, 0f);
             gunController.Fire();
             
             // if(PhotonNetwork.IsMasterClient) {
@@ -34,7 +35,8 @@ public class RobotPlayerShooter : PlayerShooter
             //gunController.photonView.RPC("RpcFire", RpcTarget.All);
 
         } else {
-            animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.Idle_gunMiddle_AR.ToString(), 1, 0f);
+            //animController.photonView.RPC("ChangeAnimationState", RpcTarget.All, PlayerAnimationController.AnimState.Idle_gunMiddle_AR.ToString(), 1, 0f);
+            animController.ChangeAnimationState(PlayerAnimationController.AnimState.Idle_gunMiddle_AR.ToString(), 1, 0f);
         }
     }
 }


### PR DESCRIPTION
점프 동작 시 상대 화면에서 떨리는 현상을 수정하기 위해 점프 함수를 rpc로 변경.
애니메이션 상태 변경 함수가 rpc를 보내기 전에 조건 검사를 먼저 하도록 바꿔, 항상 rpc를 호출하지 않도록 변경.